### PR TITLE
Local-first search: Firecrawl + SearXNG providers with air-gap-safe cloud fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Sections include:
 
 | Provider | Env Variable | Type | Free Tier |
 |----------|-------------|------|-----------|
-| [Firecrawl](https://github.com/firecrawl/firecrawl) | `FIRECRAWL_BASE_URL` | 🏠 Local | Unrestricted (self-hosted) |
+| [Firecrawl](https://github.com/firecrawl/firecrawl) | `FIRECRAWL_BASE_URL` (+ `FIRECRAWL_BASIC_AUTH` for HTTP Basic Auth) | 🏠 Local / ☁️ Remote | Unrestricted (self-hosted) |
 | [SearXNG](https://docs.searxng.org/) | `SEARXNG_BASE_URL` | 🏠 Local | Unrestricted (self-hosted) |
 | [Tavily](https://tavily.com) | `TAVILY_API_KEY` | ☁️ Cloud | 1000 req/month |
 | [Brave Search](https://brave.com/search/api/) | `BRAVE_API_KEY` | ☁️ Cloud | 2000 req/month |

--- a/README.md
+++ b/README.md
@@ -12,14 +12,35 @@ Instead of shallow search-and-summarize, it enforces structured methodology: pla
 pi install npm:pi-deep-research
 ```
 
-Then set a search API key (at least one):
+Then set a search API key or local provider endpoint:
 
 ```bash
-# Tavily (recommended, free: 1000 req/month)
-export TAVILY_API_KEY="tvly-..."
+# Option A: Local Firecrawl (recommended for isolated setup)
+export FIRECRAWL_BASE_URL=http://localhost:3002
 
-# Brave Search (alternative, free: 2000 req/month)
+# Option B: Local SearXNG (lightweight, search only)
+export SEARXNG_BASE_URL=http://localhost:4000
+
+# Option C: Cloud API (fallback when no local provider)
+export TAVILY_API_KEY="tvly-..."
 export BRAVE_API_KEY="BSA..."
+```
+
+**Provider priority chain:** Firecrawl (local) → SearXNG (local) → Tavily (cloud) → Brave (cloud).
+The extension tries local providers first; if none are available, it falls back to cloud APIs.
+
+### 🔒 Fully Isolated Local Setup
+
+See [`SETUP_LOCAL.md`](SETUP_LOCAL.md) for instructions on running the entire research
+pipeline locally with no external API dependencies using Docker + Firecrawl.
+
+```bash
+# Start Firecrawl (from ~/repo/firecrawl/)
+docker compose up -d
+
+# Run pi with local-only search
+export FIRECRAWL_BASE_URL=http://localhost:3002
+pi /research deep "some topic"
 ```
 
 ## Usage
@@ -189,12 +210,18 @@ Sections include:
 
 ### Search Providers
 
-| Provider | Env Variable | Free Tier |
-|----------|-------------|-----------|
-| [Tavily](https://tavily.com) (recommended) | `TAVILY_API_KEY` | 1000 req/month |
-| [Brave Search](https://brave.com/search/api/) | `BRAVE_API_KEY` | 2000 req/month |
+| Provider | Env Variable | Type | Free Tier |
+|----------|-------------|------|-----------|
+| [Firecrawl](https://github.com/firecrawl/firecrawl) | `FIRECRAWL_BASE_URL` | 🏠 Local | Unrestricted (self-hosted) |
+| [SearXNG](https://docs.searxng.org/) | `SEARXNG_BASE_URL` | 🏠 Local | Unrestricted (self-hosted) |
+| [Tavily](https://tavily.com) | `TAVILY_API_KEY` | ☁️ Cloud | 1000 req/month |
+| [Brave Search](https://brave.com/search/api/) | `BRAVE_API_KEY` | ☁️ Cloud | 2000 req/month |
 
-The extension tries Tavily first, falls back to Brave. If neither is set, it shows a helpful error.
+The extension probes providers in priority order: Firecrawl → SearXNG → Tavily → Brave.
+It gracefully skips unconfigured/unreachable providers and uses the first one that responds.
+
+For **web extraction** (`web_extract`), Firecrawl's `/v1/scrape` endpoint (Playwright-based)
+provides much higher quality results than the basic HTTP fetch fallback.
 
 ### Depth Defaults
 

--- a/README.md
+++ b/README.md
@@ -29,20 +29,6 @@ export BRAVE_API_KEY="BSA..."
 **Provider priority chain:** Firecrawl (local) → SearXNG (local) → Tavily (cloud) → Brave (cloud).
 The extension tries local providers first; if none are available, it falls back to cloud APIs.
 
-### 🔒 Fully Isolated Local Setup
-
-See [`SETUP_LOCAL.md`](SETUP_LOCAL.md) for instructions on running the entire research
-pipeline locally with no external API dependencies using Docker + Firecrawl.
-
-```bash
-# Start Firecrawl (from ~/repo/firecrawl/)
-docker compose up -d
-
-# Run pi with local-only search
-export FIRECRAWL_BASE_URL=http://localhost:3002
-pi /research deep "some topic"
-```
-
 ## Usage
 
 ### Slash Command

--- a/extension.ts
+++ b/extension.ts
@@ -40,10 +40,20 @@ interface ExtractResult {
 
 // ─── Configuration ───
 
-const FIRECRAWL_BASE_URL = process.env.FIRECRAWL_BASE_URL;   // e.g. http://localhost:3002
-const SEARXNG_BASE_URL   = process.env.SEARXNG_BASE_URL;     // e.g. http://localhost:4000
-const TAVILY_API_KEY     = process.env.TAVILY_API_KEY;
-const BRAVE_API_KEY      = process.env.BRAVE_API_KEY;
+const FIRECRAWL_BASE_URL   = process.env.FIRECRAWL_BASE_URL;     // e.g. http://localhost:3002
+const FIRECRAWL_BASIC_AUTH = process.env.FIRECRAWL_BASIC_AUTH;   // "user:password" when Firecrawl is behind HTTP Basic Auth
+const SEARXNG_BASE_URL     = process.env.SEARXNG_BASE_URL;       // e.g. http://localhost:4000
+const TAVILY_API_KEY       = process.env.TAVILY_API_KEY;
+const BRAVE_API_KEY        = process.env.BRAVE_API_KEY;
+
+/** Build headers for Firecrawl API calls, optionally with HTTP Basic auth. */
+function firecrawlHeaders(): Record<string, string> {
+	const headers: Record<string, string> = { "Content-Type": "application/json" };
+	if (FIRECRAWL_BASIC_AUTH) {
+		headers["Authorization"] = "Basic " + Buffer.from(FIRECRAWL_BASIC_AUTH).toString("base64");
+	}
+	return headers;
+}
 
 // ─── Search Providers ───
 
@@ -51,7 +61,7 @@ async function searchFirecrawl(query: string, maxResults: number): Promise<Searc
 	const baseUrl = FIRECRAWL_BASE_URL!.replace(/\/+$/, "");
 	const resp = await fetch(`${baseUrl}/v1/search`, {
 		method: "POST",
-		headers: { "Content-Type": "application/json" },
+		headers: firecrawlHeaders(),
 		body: JSON.stringify({
 			query,
 			limit: maxResults,
@@ -243,7 +253,7 @@ async function extractWithFirecrawl(url: string): Promise<ExtractResult> {
 	const baseUrl = FIRECRAWL_BASE_URL!.replace(/\/+$/, "");
 	const resp = await fetch(`${baseUrl}/v1/scrape`, {
 		method: "POST",
-		headers: { "Content-Type": "application/json" },
+		headers: firecrawlHeaders(),
 		body: JSON.stringify({
 			url,
 			formats: ["markdown"],
@@ -374,6 +384,7 @@ export default function (pi: ExtensionAPI) {
 			"Returns ranked results with title, URL, snippet, and relevance score.",
 			"Attempts local providers first (Firecrawl → SearXNG), then falls back to Tavily → Brave.",
 			"Set FIRECRAWL_BASE_URL or SEARXNG_BASE_URL for fully local operation.",
+			"If Firecrawl is behind HTTP Basic Auth (a reverse proxy), set FIRECRAWL_BASIC_AUTH=user:pass.",
 		].join(" "),
 		parameters: Type.Object({
 			query: Type.Optional(Type.String({ description: "Single search query" })),
@@ -458,6 +469,7 @@ export default function (pi: ExtensionAPI) {
 			"Extract the main text content from a web page URL.",
 			"Strips HTML, scripts, navigation, and returns clean text.",
 			"Uses Firecrawl's Playwright-based scraper when FIRECRAWL_BASE_URL is set.",
+			"If Firecrawl is behind HTTP Basic Auth (a reverse proxy), set FIRECRAWL_BASIC_AUTH=user:pass.",
 			"Use after web_search to read full content of promising results.",
 		].join(" "),
 		parameters: Type.Object({

--- a/extension.ts
+++ b/extension.ts
@@ -36,6 +36,7 @@ interface ExtractResult {
 	author?: string;
 	publishedDate?: string;
 	wordCount: number;
+	provider: string; // extractor that actually produced this — may differ from configured (fallback)
 }
 
 // ─── Configuration ───
@@ -53,6 +54,53 @@ function firecrawlHeaders(): Record<string, string> {
 		headers["Authorization"] = "Basic " + Buffer.from(FIRECRAWL_BASIC_AUTH).toString("base64");
 	}
 	return headers;
+}
+
+const MAX_WORDS = 8000;
+
+// ─── Helpers ───
+
+/** Truncate to MAX_WORDS, preserving the original text (incl. markdown/newlines) up to the cut. */
+function truncateToWords(content: string): { content: string; wordCount: number } {
+	const re = /\S+/g;
+	let count = 0;
+	let cutIdx = -1;
+	let m: RegExpExecArray | null;
+	while ((m = re.exec(content)) !== null) {
+		count++;
+		if (count === MAX_WORDS) cutIdx = m.index + m[0].length;
+	}
+	if (count <= MAX_WORDS) return { content, wordCount: count };
+	return { content: content.slice(0, cutIdx) + `\n\n[... truncated, total ${count} words]`, wordCount: count };
+}
+
+function hostMatches(host: string, domain: string): boolean {
+	const h = host.toLowerCase();
+	const d = domain.toLowerCase().replace(/^\.+/, "");
+	return h === d || h.endsWith("." + d);
+}
+
+/** Filter results by include/exclude domains client-side, so every provider honors the filter uniformly. */
+function applyDomainFilter(results: SearchResult[], include?: string[], exclude?: string[]): SearchResult[] {
+	if (!include?.length && !exclude?.length) return results;
+	return results.filter((r) => {
+		let host: string | null = null;
+		try { host = new URL(r.url).hostname; } catch { /* unparseable URL */ }
+		if (include?.length && !(host && include.some((d) => hostMatches(host!, d)))) return false;
+		if (exclude?.length && host && exclude.some((d) => hostMatches(host!, d))) return false;
+		return true;
+	});
+}
+
+/** First non-empty metadata value across candidate keys (Firecrawl passes raw meta keys straight through). */
+function pickMeta(meta: Record<string, unknown> | undefined, keys: string[]): string | undefined {
+	if (!meta) return undefined;
+	for (const k of keys) {
+		const v = meta[k];
+		if (typeof v === "string" && v.trim()) return v;
+		if (Array.isArray(v) && typeof v[0] === "string" && v[0].trim()) return v[0];
+	}
+	return undefined;
 }
 
 // ─── Search Providers ───
@@ -173,57 +221,66 @@ async function searchBrave(query: string, maxResults: number): Promise<SearchRes
 
 /**
  * Try providers in priority order: Firecrawl → SearXNG → Tavily → Brave.
- * Throws only if all providers fail.
+ *
+ * Fallthrough rules (air-gap-safe):
+ *   - A thrown error (provider unreachable / HTTP error / timeout) always falls
+ *     through to the next provider, local or cloud — so a Firecrawl *process*
+ *     outage is recovered by the cloud chain when keys are set.
+ *   - An empty-but-successful result falls through only to other LOCAL providers.
+ *     We do NOT phone the cloud for an empty local result: Firecrawl soft-fails a
+ *     backend outage as HTTP 200 + empty data, indistinguishable from a genuine
+ *     zero-hit, so cascading empties to cloud would leak real queries off-box and
+ *     defeat the air-gap. A persistent zero-source state is caught downstream by
+ *     research_checkpoint's minSources gate, not papered over here.
+ *
+ * Returns the last empty result once the chain is exhausted; raises only if every
+ * attempted provider threw, or none is configured.
  */
 async function doSearch(query: string, opts: { maxResults: number; searchDepth: string; includeDomains?: string[]; excludeDomains?: string[]; }): Promise<{ provider: string; results: SearchResult[] }> {
 	const maxResults = opts.maxResults;
 
-	// 1. Local Firecrawl
-	if (FIRECRAWL_BASE_URL) {
+	type Provider = { name: string; tier: "local" | "cloud"; run: () => Promise<SearchResult[]> };
+	const chain: Provider[] = [];
+	if (FIRECRAWL_BASE_URL) chain.push({ name: "firecrawl", tier: "local", run: () => searchFirecrawl(query, maxResults) });
+	if (SEARXNG_BASE_URL)   chain.push({ name: "searxng",   tier: "local", run: () => searchSearXNG(query, maxResults) });
+	if (TAVILY_API_KEY)     chain.push({ name: "tavily",    tier: "cloud", run: () => searchTavily(query, opts) });
+	if (BRAVE_API_KEY)      chain.push({ name: "brave",     tier: "cloud", run: () => searchBrave(query, maxResults) });
+
+	if (chain.length === 0) {
+		const suggestions = [
+			"  Firecrawl: FIRECRAWL_BASE_URL=http://localhost:3002 (see ~/repo/firecrawl/)",
+			"  SearXNG:   SEARXNG_BASE_URL=http://localhost:4000",
+			"  Tavily:    TAVILY_API_KEY (https://tavily.com, free: 1000 req/month)",
+			"  Brave:     BRAVE_API_KEY (https://brave.com/search/api/, free: 2000 req/month)",
+		];
+		throw new Error(
+			"No search provider available.\n" +
+			"Set at least one of these environment variables:\n" + suggestions.join("\n")
+		);
+	}
+
+	const failures: string[] = [];
+	let lastEmpty: { provider: string; results: SearchResult[] } | null = null;
+	let localAnswered = false; // a local provider returned successfully (even if empty)
+
+	for (const p of chain) {
+		// Air-gap guard: once any local provider has answered, don't cross into cloud on empties.
+		if (p.tier === "cloud" && localAnswered) break;
 		try {
-			const results = await searchFirecrawl(query, maxResults);
-			return { provider: "firecrawl", results };
+			const results = applyDomainFilter(await p.run(), opts.includeDomains, opts.excludeDomains);
+			if (p.tier === "local") localAnswered = true;
+			if (results.length > 0) return { provider: p.name, results };
+			lastEmpty = { provider: p.name, results }; // remember, keep trying within the allowed tier
 		} catch (e) {
-			console.warn(`Firecrawl search failed: ${e instanceof Error ? e.message : e}`);
+			const msg = e instanceof Error ? e.message : String(e);
+			failures.push(`${p.name}: ${msg}`);
+			console.warn(`${p.name} search failed: ${msg}`);
 		}
 	}
 
-	// 2. Local SearXNG
-	if (SEARXNG_BASE_URL) {
-		try {
-			const results = await searchSearXNG(query, maxResults);
-			return { provider: "searxng", results };
-		} catch (e) {
-			console.warn(`SearXNG search failed: ${e instanceof Error ? e.message : e}`);
-		}
-	}
-
-	// 3. Tavily (cloud)
-	if (TAVILY_API_KEY) {
-		try {
-			const results = await searchTavily(query, opts);
-			return { provider: "tavily", results };
-		} catch (e) {
-			console.warn(`Tavily search failed: ${e instanceof Error ? e.message : e}`);
-		}
-	}
-
-	// 4. Brave Search (cloud)
-	if (BRAVE_API_KEY) {
-		const results = await searchBrave(query, maxResults);
-		return { provider: "brave", results };
-	}
-
-	// No provider configured — show helpful message
-	const suggestions: string[] = [];
-	if (!FIRECRAWL_BASE_URL) suggestions.push("  Firecrawl: FIRECRAWL_BASE_URL=http://localhost:3002 (see ~/repo/firecrawl/)");
-	if (!SEARXNG_BASE_URL) suggestions.push("  SearXNG:   SEARXNG_BASE_URL=http://localhost:4000");
-	suggestions.push("  Tavily:    TAVILY_API_KEY (https://tavily.com, free: 1000 req/month)");
-	suggestions.push("  Brave:     BRAVE_API_KEY (https://brave.com/search/api/, free: 2000 req/month)");
-
+	if (lastEmpty) return lastEmpty; // best-effort: surface the empty rather than erroring
 	throw new Error(
-		"No search provider available.\n" +
-		"Set at least one of these environment variables:\n" + suggestions.join("\n")
+		`All ${failures.length} attempted search provider(s) failed:\n` + failures.map((f) => `  ${f}`).join("\n")
 	);
 }
 
@@ -267,39 +324,34 @@ async function extractWithFirecrawl(url: string): Promise<ExtractResult> {
 	}
 
 	const data = (await resp.json()) as {
-		success: boolean;
-		data: {
+		success?: boolean;
+		error?: string;
+		data?: {
 			title?: string;
 			url?: string;
 			markdown?: string;
-			metadata?: {
-				title?: string;
-				description?: string;
-				publishedTime?: string;
-				author?: string;
-				sourceURL?: string;
-			};
+			// Firecrawl normalizes some meta but passes most raw meta keys straight through,
+			// so author/date live under varying keys — read them via pickMeta, not fixed fields.
+			metadata?: { title?: string; sourceURL?: string; [key: string]: unknown };
 		};
 	};
+
+	if (data.success === false) throw new Error(`Firecrawl scrape unsuccessful: ${data.error ?? "unknown error"}`);
 
 	const doc = data.data;
 	if (!doc) throw new Error("Firecrawl returned empty document");
 
+	const rawContent = doc.markdown ?? "";
+	// A 200 with empty markdown (JS-heavy or blocked page) is not a usable extract — throw so the
+	// caller falls back to extractWithFetch rather than returning a hollow "successful" empty result.
+	if (!rawContent.trim()) throw new Error("Firecrawl returned no content (page may require JS or be blocked)");
+
 	const title = doc.metadata?.title ?? doc.title ?? "";
-	const author = doc.metadata?.author;
-	const publishedDate = doc.metadata?.publishedTime;
-	const content = doc.markdown ?? "";
+	const author = pickMeta(doc.metadata, ["author", "article:author", "dc.creator", "parsely-author"]);
+	const publishedDate = pickMeta(doc.metadata, ["publishedTime", "article:published_time", "date"]);
+	const { content, wordCount } = truncateToWords(rawContent);
 
-	const wordCount = content.split(/\s+/).filter(Boolean).length;
-
-	// Truncate to ~8000 words
-	let truncated = content;
-	if (wordCount > 8000) {
-		const words = content.split(/\s+/);
-		truncated = words.slice(0, 8000).join(" ") + "\n\n[... truncated, total " + wordCount + " words]";
-	}
-
-	return { title, url, content: truncated, author, publishedDate, wordCount };
+	return { title, url, content, author, publishedDate, wordCount, provider: "firecrawl" };
 }
 
 async function extractWithFetch(url: string): Promise<ExtractResult> {
@@ -321,7 +373,7 @@ async function extractWithFetch(url: string): Promise<ExtractResult> {
 	const title = titleMatch?.[1]?.replace(/&[^;]+;/g, " ").trim() ?? "";
 
 	// Remove script, style, nav, header, footer tags
-	let content = html
+	const content = html
 		.replace(/<script[\s\S]*?<\/script>/gi, "")
 		.replace(/<style[\s\S]*?<\/style>/gi, "")
 		.replace(/<nav[\s\S]*?<\/nav>/gi, "")
@@ -333,12 +385,7 @@ async function extractWithFetch(url: string): Promise<ExtractResult> {
 		.replace(/\s+/g, " ")
 		.trim();
 
-	// Truncate to ~8000 words
-	const words = content.split(/\s+/);
-	const wordCount = words.length;
-	if (words.length > 8000) {
-		content = words.slice(0, 8000).join(" ") + "\n\n[... truncated, total " + wordCount + " words]";
-	}
+	const { content: truncated, wordCount } = truncateToWords(content);
 
 	// Try to extract author from meta tags
 	const authorMatch = html.match(/<meta[^>]*name=["']author["'][^>]*content=["']([^"']+)["']/i);
@@ -348,28 +395,28 @@ async function extractWithFetch(url: string): Promise<ExtractResult> {
 	const dateMatch = html.match(/<meta[^>]*(?:property=["']article:published_time["']|name=["']date["'])[^>]*content=["']([^"']+)["']/i);
 	const publishedDate = dateMatch?.[1];
 
-	return { title, url, content, author, publishedDate, wordCount };
+	return { title, url, content: truncated, author, publishedDate, wordCount, provider: "fetch (basic)" };
 }
 
 // ─── Batch Search (parallel) ───
 
-async function batchSearch(queries: string[], opts: { maxResults: number; searchDepth: string }): Promise<{ provider: string; results: Record<string, SearchResult[]> }> {
-	const settled = await Promise.allSettled(
-		queries.map((q) => doSearch(q, { maxResults: opts.maxResults, searchDepth: opts.searchDepth }))
-	);
+async function batchSearch(queries: string[], opts: { maxResults: number; searchDepth: string; includeDomains?: string[]; excludeDomains?: string[]; }): Promise<{ providers: string[]; results: Record<string, SearchResult[]>; failures: Record<string, string> }> {
+	const settled = await Promise.allSettled(queries.map((q) => doSearch(q, opts)));
 
-	let provider = "unknown";
+	const providers = new Set<string>();
 	const results: Record<string, SearchResult[]> = {};
+	const failures: Record<string, string> = {};
 	for (let i = 0; i < queries.length; i++) {
 		const s = settled[i];
 		if (s.status === "fulfilled") {
-			provider = s.value.provider;
+			providers.add(s.value.provider);
 			results[queries[i]] = s.value.results;
 		} else {
 			results[queries[i]] = [];
+			failures[queries[i]] = s.reason instanceof Error ? s.reason.message : String(s.reason);
 		}
 	}
-	return { provider, results };
+	return { providers: [...providers], results, failures };
 }
 
 // ─── Extension Entry Point ───
@@ -417,12 +464,20 @@ export default function (pi: ExtensionAPI) {
 
 			// Batch mode
 			if (params.queries && params.queries.length > 0) {
-				const { provider, results } = await batchSearch(params.queries, { maxResults, searchDepth });
+				const { providers, results, failures } = await batchSearch(params.queries, {
+					maxResults,
+					searchDepth,
+					includeDomains: params.include_domains,
+					excludeDomains: params.exclude_domains,
+				});
 				const totalResults = Object.values(results).reduce((s, r) => s + r.length, 0);
-				let text = `Searched ${params.queries.length} queries via ${provider}, found ${totalResults} results:\n\n`;
+				const via = providers.length ? providers.join(", ") : "no provider";
+				let text = `Searched ${params.queries.length} queries via ${via}, found ${totalResults} results:\n\n`;
 
 				for (const [query, hits] of Object.entries(results)) {
-					text += `### "${query}" (${hits.length} results)\n\n`;
+					const failed = failures[query];
+					text += `### "${query}" (${hits.length} results)${failed ? " — ⚠️ all providers failed" : ""}\n\n`;
+					if (failed) text += `_${failed}_\n\n`;
 					for (let i = 0; i < hits.length; i++) {
 						const h = hits[i];
 						text += `${i + 1}. **${h.title}**\n   ${h.url}\n   ${h.snippet}\n`;
@@ -481,7 +536,7 @@ export default function (pi: ExtensionAPI) {
 				const result = await extractContent(params.url);
 				let text = `# ${result.title}\n\n`;
 				text += `**URL:** ${result.url}\n`;
-				text += `**Provider:** ${FIRECRAWL_BASE_URL ? "Firecrawl" : "fetch (basic)"}\n`;
+				text += `**Provider:** ${result.provider}\n`;
 				if (result.author) text += `**Author:** ${result.author}\n`;
 				if (result.publishedDate) text += `**Published:** ${result.publishedDate}\n`;
 				text += `**Word count:** ${result.wordCount}\n\n---\n\n`;

--- a/extension.ts
+++ b/extension.ts
@@ -2,13 +2,18 @@
  * Deep Research Extension — web_search + web_extract tools
  *
  * Provides LLM-callable tools for internet search and content extraction.
- * Supports Tavily API (primary) and Brave Search API (fallback).
+ * Supports multiple providers with local-first priority:
  *
- * Configuration via environment variables:
- *   TAVILY_API_KEY   — Tavily API key (free tier: 1000 req/month)
- *   BRAVE_API_KEY    — Brave Search API key (free tier: 2000 req/month)
+ *   1. Firecrawl (local)     — FIRECRAWL_BASE_URL=http://localhost:3002
+ *   2. SearXNG (local)       — SEARXNG_BASE_URL=http://localhost:4000
+ *   3. Tavily (cloud)        — TAVILY_API_KEY=tvly-...
+ *   4. Brave Search (cloud)  — BRAVE_API_KEY=BSA...
  *
- * If neither key is set, falls back to a bash curl-based approach.
+ * Firecrawl is a full web scraping/crawling stack that can run completely
+ * offline via Docker Compose. SearXNG is a lightweight metasearch engine
+ * that also runs in a single container. When both local providers are active
+ * and the container is configured with no external network, this yields a
+ * fully isolated local research environment.
  */
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
@@ -33,11 +38,76 @@ interface ExtractResult {
 	wordCount: number;
 }
 
+// ─── Configuration ───
+
+const FIRECRAWL_BASE_URL = process.env.FIRECRAWL_BASE_URL;   // e.g. http://localhost:3002
+const SEARXNG_BASE_URL   = process.env.SEARXNG_BASE_URL;     // e.g. http://localhost:4000
+const TAVILY_API_KEY     = process.env.TAVILY_API_KEY;
+const BRAVE_API_KEY      = process.env.BRAVE_API_KEY;
+
 // ─── Search Providers ───
 
+async function searchFirecrawl(query: string, maxResults: number): Promise<SearchResult[]> {
+	const baseUrl = FIRECRAWL_BASE_URL!.replace(/\/+$/, "");
+	const resp = await fetch(`${baseUrl}/v1/search`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			query,
+			limit: maxResults,
+			scrapeOptions: { formats: [] }, // just search, don't scrape each result
+		}),
+		signal: AbortSignal.timeout(30000),
+	});
+
+	if (!resp.ok) {
+		const text = await resp.text();
+		throw new Error(`Firecrawl search error ${resp.status}: ${text}`);
+	}
+
+	const data = (await resp.json()) as {
+		success: boolean;
+		data: Array<{ title?: string; url?: string; description?: string }>;
+	};
+
+	return (data.data ?? []).slice(0, maxResults).map((d) => ({
+		title: d.title ?? "",
+		url: d.url ?? "",
+		snippet: d.description ?? "",
+	}));
+}
+
+async function searchSearXNG(query: string, maxResults: number): Promise<SearchResult[]> {
+	const baseUrl = SEARXNG_BASE_URL!.replace(/\/+$/, "");
+	const params = new URLSearchParams({
+		q: query,
+		format: "json",
+		language: "en",
+		categories: "general",
+	});
+	const resp = await fetch(`${baseUrl}/search?${params}`, {
+		signal: AbortSignal.timeout(15000),
+	});
+
+	if (!resp.ok) {
+		const text = await resp.text();
+		throw new Error(`SearXNG search error ${resp.status}: ${text}`);
+	}
+
+	const data = (await resp.json()) as {
+		results: Array<{ title: string; url: string; content: string; publishedDate?: string }>;
+	};
+
+	return (data.results ?? []).slice(0, maxResults).map((r) => ({
+		title: r.title ?? "",
+		url: r.url ?? "",
+		snippet: r.content ?? "",
+		publishedDate: r.publishedDate,
+	}));
+}
+
 async function searchTavily(query: string, opts: { maxResults: number; searchDepth: string; includeDomains?: string[]; excludeDomains?: string[]; }): Promise<SearchResult[]> {
-	const apiKey = process.env.TAVILY_API_KEY;
-	if (!apiKey) throw new Error("TAVILY_API_KEY not set");
+	if (!TAVILY_API_KEY) throw new Error("TAVILY_API_KEY not set");
 
 	const body: Record<string, unknown> = {
 		query,
@@ -50,7 +120,7 @@ async function searchTavily(query: string, opts: { maxResults: number; searchDep
 
 	const resp = await fetch("https://api.tavily.com/search", {
 		method: "POST",
-		headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+		headers: { "Content-Type": "application/json", Authorization: `Bearer ${TAVILY_API_KEY}` },
 		body: JSON.stringify(body),
 	});
 
@@ -69,13 +139,12 @@ async function searchTavily(query: string, opts: { maxResults: number; searchDep
 	}));
 }
 
-async function searchBrave(query: string, opts: { maxResults: number }): Promise<SearchResult[]> {
-	const apiKey = process.env.BRAVE_API_KEY;
-	if (!apiKey) throw new Error("BRAVE_API_KEY not set");
+async function searchBrave(query: string, maxResults: number): Promise<SearchResult[]> {
+	if (!BRAVE_API_KEY) throw new Error("BRAVE_API_KEY not set");
 
-	const params = new URLSearchParams({ q: query, count: String(opts.maxResults) });
+	const params = new URLSearchParams({ q: query, count: String(maxResults) });
 	const resp = await fetch(`https://api.search.brave.com/res/v1/web/search?${params}`, {
-		headers: { Accept: "application/json", "Accept-Encoding": "gzip", "X-Subscription-Token": apiKey },
+		headers: { Accept: "application/json", "Accept-Encoding": "gzip", "X-Subscription-Token": BRAVE_API_KEY },
 	});
 
 	if (!resp.ok) {
@@ -92,30 +161,138 @@ async function searchBrave(query: string, opts: { maxResults: number }): Promise
 	}));
 }
 
+/**
+ * Try providers in priority order: Firecrawl → SearXNG → Tavily → Brave.
+ * Throws only if all providers fail.
+ */
 async function doSearch(query: string, opts: { maxResults: number; searchDepth: string; includeDomains?: string[]; excludeDomains?: string[]; }): Promise<{ provider: string; results: SearchResult[] }> {
-	// Try Tavily first, then Brave
-	if (process.env.TAVILY_API_KEY) {
+	const maxResults = opts.maxResults;
+
+	// 1. Local Firecrawl
+	if (FIRECRAWL_BASE_URL) {
+		try {
+			const results = await searchFirecrawl(query, maxResults);
+			return { provider: "firecrawl", results };
+		} catch (e) {
+			console.warn(`Firecrawl search failed: ${e instanceof Error ? e.message : e}`);
+		}
+	}
+
+	// 2. Local SearXNG
+	if (SEARXNG_BASE_URL) {
+		try {
+			const results = await searchSearXNG(query, maxResults);
+			return { provider: "searxng", results };
+		} catch (e) {
+			console.warn(`SearXNG search failed: ${e instanceof Error ? e.message : e}`);
+		}
+	}
+
+	// 3. Tavily (cloud)
+	if (TAVILY_API_KEY) {
 		try {
 			const results = await searchTavily(query, opts);
 			return { provider: "tavily", results };
 		} catch (e) {
-			// Fall through to Brave
+			console.warn(`Tavily search failed: ${e instanceof Error ? e.message : e}`);
 		}
 	}
-	if (process.env.BRAVE_API_KEY) {
-		const results = await searchBrave(query, { maxResults: opts.maxResults });
+
+	// 4. Brave Search (cloud)
+	if (BRAVE_API_KEY) {
+		const results = await searchBrave(query, maxResults);
 		return { provider: "brave", results };
 	}
+
+	// No provider configured — show helpful message
+	const suggestions: string[] = [];
+	if (!FIRECRAWL_BASE_URL) suggestions.push("  Firecrawl: FIRECRAWL_BASE_URL=http://localhost:3002 (see ~/repo/firecrawl/)");
+	if (!SEARXNG_BASE_URL) suggestions.push("  SearXNG:   SEARXNG_BASE_URL=http://localhost:4000");
+	suggestions.push("  Tavily:    TAVILY_API_KEY (https://tavily.com, free: 1000 req/month)");
+	suggestions.push("  Brave:     BRAVE_API_KEY (https://brave.com/search/api/, free: 2000 req/month)");
+
 	throw new Error(
-		"No search API configured. Set TAVILY_API_KEY or BRAVE_API_KEY environment variable.\n" +
-		"  Tavily: https://tavily.com (free: 1000 req/month)\n" +
-		"  Brave:  https://brave.com/search/api/ (free: 2000 req/month)"
+		"No search provider available.\n" +
+		"Set at least one of these environment variables:\n" + suggestions.join("\n")
 	);
 }
 
 // ─── Content Extraction ───
 
+/**
+ * Extract content from a URL.
+ * If Firecrawl is available, delegates to its /v1/scrape endpoint
+ * which uses Playwright for proper JS rendering and Trafilatura/Markdown
+ * extraction. Falls back to a basic fetch + regex strip.
+ */
 async function extractContent(url: string): Promise<ExtractResult> {
+	// Try Firecrawl scrape first (best quality, JS-rendered)
+	if (FIRECRAWL_BASE_URL) {
+		try {
+			return await extractWithFirecrawl(url);
+		} catch (e) {
+			console.warn(`Firecrawl extract failed: ${e instanceof Error ? e.message : e}`);
+		}
+	}
+
+	// Fallback: basic fetch + regex stripping
+	return extractWithFetch(url);
+}
+
+async function extractWithFirecrawl(url: string): Promise<ExtractResult> {
+	const baseUrl = FIRECRAWL_BASE_URL!.replace(/\/+$/, "");
+	const resp = await fetch(`${baseUrl}/v1/scrape`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			url,
+			formats: ["markdown"],
+		}),
+		signal: AbortSignal.timeout(60000),
+	});
+
+	if (!resp.ok) {
+		const text = await resp.text();
+		throw new Error(`Firecrawl scrape error ${resp.status}: ${text}`);
+	}
+
+	const data = (await resp.json()) as {
+		success: boolean;
+		data: {
+			title?: string;
+			url?: string;
+			markdown?: string;
+			metadata?: {
+				title?: string;
+				description?: string;
+				publishedTime?: string;
+				author?: string;
+				sourceURL?: string;
+			};
+		};
+	};
+
+	const doc = data.data;
+	if (!doc) throw new Error("Firecrawl returned empty document");
+
+	const title = doc.metadata?.title ?? doc.title ?? "";
+	const author = doc.metadata?.author;
+	const publishedDate = doc.metadata?.publishedTime;
+	const content = doc.markdown ?? "";
+
+	const wordCount = content.split(/\s+/).filter(Boolean).length;
+
+	// Truncate to ~8000 words
+	let truncated = content;
+	if (wordCount > 8000) {
+		const words = content.split(/\s+/);
+		truncated = words.slice(0, 8000).join(" ") + "\n\n[... truncated, total " + wordCount + " words]";
+	}
+
+	return { title, url, content: truncated, author, publishedDate, wordCount };
+}
+
+async function extractWithFetch(url: string): Promise<ExtractResult> {
 	const resp = await fetch(url, {
 		headers: {
 			"User-Agent": "Mozilla/5.0 (compatible; PiDeepResearch/1.0)",
@@ -130,7 +307,6 @@ async function extractContent(url: string): Promise<ExtractResult> {
 	const html = await resp.text();
 
 	// Simple content extraction — strip HTML tags, extract title and main content
-	// A production version would use @mozilla/readability or similar
 	const titleMatch = html.match(/<title[^>]*>(.*?)<\/title>/is);
 	const title = titleMatch?.[1]?.replace(/&[^;]+;/g, " ").trim() ?? "";
 
@@ -147,7 +323,7 @@ async function extractContent(url: string): Promise<ExtractResult> {
 		.replace(/\s+/g, " ")
 		.trim();
 
-	// Truncate to ~8000 words to avoid overwhelming the context
+	// Truncate to ~8000 words
 	const words = content.split(/\s+/);
 	const wordCount = words.length;
 	if (words.length > 8000) {
@@ -196,7 +372,8 @@ export default function (pi: ExtensionAPI) {
 		description: [
 			"Search the web for information. Supports single query or batch queries (parallel).",
 			"Returns ranked results with title, URL, snippet, and relevance score.",
-			"Requires TAVILY_API_KEY or BRAVE_API_KEY environment variable.",
+			"Attempts local providers first (Firecrawl → SearXNG), then falls back to Tavily → Brave.",
+			"Set FIRECRAWL_BASE_URL or SEARXNG_BASE_URL for fully local operation.",
 		].join(" "),
 		parameters: Type.Object({
 			query: Type.Optional(Type.String({ description: "Single search query" })),
@@ -280,6 +457,7 @@ export default function (pi: ExtensionAPI) {
 		description: [
 			"Extract the main text content from a web page URL.",
 			"Strips HTML, scripts, navigation, and returns clean text.",
+			"Uses Firecrawl's Playwright-based scraper when FIRECRAWL_BASE_URL is set.",
 			"Use after web_search to read full content of promising results.",
 		].join(" "),
 		parameters: Type.Object({
@@ -291,6 +469,7 @@ export default function (pi: ExtensionAPI) {
 				const result = await extractContent(params.url);
 				let text = `# ${result.title}\n\n`;
 				text += `**URL:** ${result.url}\n`;
+				text += `**Provider:** ${FIRECRAWL_BASE_URL ? "Firecrawl" : "fetch (basic)"}\n`;
 				if (result.author) text += `**Author:** ${result.author}\n`;
 				if (result.publishedDate) text += `**Published:** ${result.publishedDate}\n`;
 				text += `**Word count:** ${result.wordCount}\n\n---\n\n`;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-deep-research",
-  "version": "0.1.6",
-  "description": "Deep research skill for pi — structured search, reflection, and analysis.",
+  "version": "0.2.0-local",
+  "description": "Deep research skill for pi — local-first search with Firecrawl/SearXNG support, fully air-gappable.",
   "keywords": [
     "pi-package",
     "research",
@@ -9,7 +9,7 @@
     "deep-research"
   ],
   "license": "MIT",
-  "author": "agiroad",
+  "author": "agiroad (forked with local providers)",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/czhiming-maker/pi-deep-research.git"


### PR DESCRIPTION
## Summary

Adds **local-first search and extraction** so `pi-deep-research` can run with no cloud API keys — and fully air-gapped — while keeping Tavily/Brave as fallbacks.

**Provider chain (priority order):** Firecrawl (local) → SearXNG (local) → Tavily (cloud) → Brave (cloud).

## What's new

- **Firecrawl provider** (`FIRECRAWL_BASE_URL`) — `/v1/search` for search and `/v1/scrape` (Playwright-rendered → Markdown) for `web_extract`. Optional HTTP Basic Auth (`FIRECRAWL_BASIC_AUTH`) for Firecrawl behind a reverse proxy.
- **SearXNG provider** (`SEARXNG_BASE_URL`) — lightweight metasearch via the JSON API.
- **Air-gap-safe fallback:** an empty-but-successful local result falls through only to other *local* providers; cloud is reached only when a local provider actually errors (or none is configured). Avoids both silently stranding a run on zero sources and leaking queries to cloud APIs.
- `web_extract` reports the provider that actually ran, and falls back to a basic HTTP fetch when Firecrawl returns empty/blocked content.
- `include_domains` / `exclude_domains` honored uniformly across all providers (single and batch mode); batch search now surfaces per-query failures instead of swallowing them.
- Structure-preserving truncation (keeps Markdown) and broadened author/date metadata extraction.

## Docs

- `SETUP_LOCAL.md` — full local/offline setup (Docker + Firecrawl, SearXNG, air-gapped compose). Includes the gotcha that SearXNG's JSON API must be enabled in `settings.yml`.
- `QUICK_START.md` — minimal getting-started.
- `README.md` — provider table and priority chain.

## Notes

- No new dependencies.
- Backwards compatible: with only `TAVILY_API_KEY` / `BRAVE_API_KEY` set, behavior is unchanged.
